### PR TITLE
微信授权和重定向

### DIFF
--- a/app/Http/Controllers/Wechat/WechatApiController.php
+++ b/app/Http/Controllers/Wechat/WechatApiController.php
@@ -14,7 +14,7 @@ class WechatApiController extends Controller {
     protected $_appNotify;
     public function __construct()
     {
-        $this->_appNotify = Factory::officialAccount(config('wechat.official_account'));
+        $this->_appNotify = Factory::officialAccount(config('wechat.official_account.default'));
     }
 
     //公众号事件入口

--- a/app/Http/Controllers/Wechat/WechatApiController.php
+++ b/app/Http/Controllers/Wechat/WechatApiController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Wechat;
 
 
 use App\Http\Controllers\Controller;
+use EasyWeChat\Factory;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 
@@ -13,7 +14,7 @@ class WechatApiController extends Controller {
     protected $_appNotify;
     public function __construct()
     {
-        $this->_appNotify = app('wechat.official_account');
+        $this->_appNotify = Factory::officialAccount(config('wechat.official_account'));
     }
 
     //公众号事件入口

--- a/app/Http/Controllers/Wechat/WechatLoginController.php
+++ b/app/Http/Controllers/Wechat/WechatLoginController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers\Wechat;
 
 
 use App\Http\Controllers\Controller;
+use App\Http\Controllers\Jwt\JwtController;
+use App\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use EasyWeChat\Factory;
@@ -20,13 +22,23 @@ class WechatLoginController extends Controller {
     }
 
 
+    /**
+     * 公众号授权
+     * 流程：
+     * 当用户访问一个需要授权页面时，如 baidu.com
+     * 前端需要调用该授权接口进行授权，授权完后微信会调用回调接口
+     * 在回调接口里面保存用户信息，并且重定向到用户要访问的页面：baidu.com
+     * @param Request $request
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     */
     public function wechatAuth(Request $request) {
 
+        // 获取用户要访问页面的 url
         $url = $request->get('url');
         Log::info('重定向的url：' . $url);
 
+        // 将 该重定向的 url 编码后拼接到回调接口中
         $url = '?url=' . urlencode($url);
-
         $this->config['oauth']['callback'] .= $url;
         $app = Factory::officialAccount($this->config);
 
@@ -34,16 +46,63 @@ class WechatLoginController extends Controller {
             ->redirect();
     }
 
+    /**
+     * 授权回调流程：
+     * 该接口为授权回调接口，在授权接口中将该接口地址一起给微信（一般写在配置中）
+     * 用户点击授权后，微信将通过该回调地址将用户的 code 传过来
+     * 由于在授权接口中将用户访问的页面 url 拼接到回调地址后面
+     * 因此微信调用 回调接口的时候，后面会带有 ?url=xxx 等参数
+     * 这些参数可以在回调接口中获取到
+     * @param Request $request
+     * @return \Illuminate\Http\RedirectResponse
+     */
     public function callback(Request $request) {
         Log::info('获取用户的code:  ' . $request->get('code'));
+
+        //从回调地址中获取需要重定向的 url 参数
         $targetUrl = $request->get('url','/');
-        Log::info('重定向的url：' . $targetUrl);
 
-        $wechatUserInfo = $this->_appNotify->oauth->user();
-        $wechatUserInfo = $wechatUserInfo->original;
-        Log::info('微信返回得用户信息：' . json_encode($wechatUserInfo));
+        // 重定向的 url 上也有可能带有参数，因此需要用 & 判断
+        // 我们需要将生成的 token 放到重定向的 url 中
+        // 前端将会获取 url 中的 token，并且截取下来，放入 header 中
+        // 并且指定 key 为 token （这个值随便，方式需要在取的时候一致），
+        // 方便后端验证 token 的时候取值
+        if (count(explode('&', $targetUrl)) > 1) {
+            $targetUrl = $targetUrl . '&token=';
+        } else {
+            $targetUrl = $targetUrl . '?token=';
+        }
 
-        return redirect()->to($targetUrl);
+        try {
+            $wechatUserInfo = $this->_appNotify->oauth->user();
+            $wechatUserInfo = $wechatUserInfo->original;
+            Log::info('微信返回得用户信息：' . json_encode($wechatUserInfo));
+
+            // 这里使用 openid 判断用户是否注册
+            $userInfo = User::where('openid',$wechatUserInfo['openid'])->first();
+            // 如果用户已经存在，则返回 token 直接登录
+            $jwt = new JwtController();
+            if ($userInfo) {
+                return redirect()->to($targetUrl . 'Bearer'. $jwt->encrypt($userInfo));
+            }
+
+            // 没有则添加用户信息
+            $save = [
+                'openid' => $wechatUserInfo['openid'],
+                'nickname' => $wechatUserInfo['nickname'],
+                'headimgurl' => $wechatUserInfo['headimgurl'],
+                'created_at' => time(),
+                'updated_at' => time()
+            ];
+
+            $id = User::insertGetId($save);
+            $userInfo = User::where('id',$id)->first();
+            return redirect()->to($targetUrl . 'Bearer'. $jwt->encrypt($userInfo));
+        } catch (\Exception $e) {
+            Log::error('用户授权出错：' . $e->getMessage());
+            return redirect()->to($targetUrl);
+        }
+
     }
 
 

--- a/app/Http/Controllers/Wechat/WechatLoginController.php
+++ b/app/Http/Controllers/Wechat/WechatLoginController.php
@@ -13,9 +13,11 @@ use EasyWeChat\Factory;
 class WechatLoginController extends Controller {
 
     protected $_appNotify;
+    protected $config;
     public function __construct()
     {
-        $this->_appNotify = Factory::officialAccount(config('wechat.official_account'));
+        $this->config = config('wechat.official_account');
+        $this->_appNotify = Factory::officialAccount($this->config);
     }
 
 
@@ -24,20 +26,24 @@ class WechatLoginController extends Controller {
         $url = $request->get('url');
         Log::info('重定向的url：' . $url);
 
+        $url = '?url=' . urlencode($url);
+        $this->config['default']['oauth']['callback'] .= $url;
+
         return $this->_appNotify->oauth
             ->scopes(['snsapi_userinfo'])
-            ->setRequest($request)
             ->redirect();
     }
 
     public function callback(Request $request) {
         Log::info('获取用户的code:  ' . $request->get('code'));
-        $targetUrl = $request->get('url');
+        $targetUrl = $request->get('url','/');
         Log::info('重定向的url：' . $targetUrl);
 
         $wechatUserInfo = $this->_appNotify->oauth->user();
         $wechatUserInfo = $wechatUserInfo->original;
         Log::info('微信返回得用户信息：' . json_encode($wechatUserInfo));
+
+        return redirect()->to($targetUrl);
     }
 
 

--- a/app/Http/Controllers/Wechat/WechatLoginController.php
+++ b/app/Http/Controllers/Wechat/WechatLoginController.php
@@ -17,7 +17,7 @@ class WechatLoginController extends Controller {
     public function __construct()
     {
         $this->config = config('wechat.official_account');
-        $this->_appNotify = Factory::officialAccount($this->config);
+        $this->_appNotify = app('wechat.official_account');
     }
 
 
@@ -27,10 +27,11 @@ class WechatLoginController extends Controller {
         Log::info('重定向的url：' . $url);
 
         $url = '?url=' . urlencode($url);
-        $this->config['default']['oauth']['callback'] .= $url;
 
-        return $this->_appNotify->oauth
-            ->scopes(['snsapi_userinfo'])
+        $this->config['default']['oauth']['callback'] .= $url;
+        $app = Factory::officialAccount($this->config);
+
+        return $app->oauth->scopes(['snsapi_userinfo'])
             ->redirect();
     }
 

--- a/app/Http/Controllers/Wechat/WechatLoginController.php
+++ b/app/Http/Controllers/Wechat/WechatLoginController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Wechat;
 
 
 use App\Http\Controllers\Controller;
-use App\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use EasyWeChat\Factory;
@@ -16,7 +15,7 @@ class WechatLoginController extends Controller {
     protected $config;
     public function __construct()
     {
-        $this->config = config('wechat.official_account');
+        $this->config = config('wechat.official_account.default');
         $this->_appNotify = app('wechat.official_account');
     }
 
@@ -28,7 +27,7 @@ class WechatLoginController extends Controller {
 
         $url = '?url=' . urlencode($url);
 
-        $this->config['default']['oauth']['callback'] .= $url;
+        $this->config['oauth']['callback'] .= $url;
         $app = Factory::officialAccount($this->config);
 
         return $app->oauth->scopes(['snsapi_userinfo'])

--- a/app/Http/Controllers/Wechat/WechatLoginController.php
+++ b/app/Http/Controllers/Wechat/WechatLoginController.php
@@ -5,15 +5,40 @@ namespace App\Http\Controllers\Wechat;
 
 
 use App\Http\Controllers\Controller;
+use App\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use EasyWeChat\Factory;
 
 class WechatLoginController extends Controller {
 
-    public function wechatLogin(Request $request) {
-
-
+    protected $_appNotify;
+    public function __construct()
+    {
+        $this->_appNotify = Factory::officialAccount(config('wechat.official_account'));
     }
 
+
+    public function wechatAuth(Request $request) {
+
+        $url = $request->get('url');
+        Log::info('重定向的url：' . $url);
+
+        return $this->_appNotify->oauth
+            ->scopes(['snsapi_userinfo'])
+            ->setRequest($request)
+            ->redirect();
+    }
+
+    public function callback(Request $request) {
+        Log::info('获取用户的code:  ' . $request->get('code'));
+        $targetUrl = $request->get('url');
+        Log::info('重定向的url：' . $targetUrl);
+
+        $wechatUserInfo = $this->_appNotify->oauth->user();
+        $wechatUserInfo = $wechatUserInfo->original;
+        Log::info('微信返回得用户信息：' . json_encode($wechatUserInfo));
+    }
 
 
 }

--- a/app/Http/Controllers/Wechat/WechatLoginController.php
+++ b/app/Http/Controllers/Wechat/WechatLoginController.php
@@ -16,7 +16,7 @@ class WechatLoginController extends Controller {
     public function __construct()
     {
         $this->config = config('wechat.official_account.default');
-        $this->_appNotify = app('wechat.official_account');
+        $this->_appNotify = Factory::officialAccount($this->config);
     }
 
 

--- a/config/wechat.php
+++ b/config/wechat.php
@@ -70,10 +70,10 @@ return [
              * scopes：公众平台（snsapi_userinfo / snsapi_base），开放平台：snsapi_login
              * callback：OAuth授权完成后的回调页地址(如果使用中间件，则随便填写。。。)
              */
-            // 'oauth' => [
-            //     'scopes'   => array_map('trim', explode(',', env('WECHAT_OFFICIAL_ACCOUNT_OAUTH_SCOPES', 'snsapi_userinfo'))),
-            //     'callback' => env('WECHAT_OFFICIAL_ACCOUNT_OAUTH_CALLBACK', '/examples/oauth_callback.php'),
-            // ],
+             'oauth' => [
+                 'scopes'   => array_map('trim', explode(',', env('WECHAT_OFFICIAL_ACCOUNT_OAUTH_SCOPES', 'snsapi_base'))),
+                 'callback' => env('WECHAT_OFFICIAL_ACCOUNT_OAUTH_CALLBACK', '/api/wechat/callback'),
+             ],
         ],
     ],
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,6 +20,9 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 
 // 微信公众号入口
 Route::any('/wechat/entrance','Wechat\WechatApiController@entrance');
+// 微信授权和回调
+Route::any('/wechat/wechatOauth','Wechat\WechatLoginController@wechatAuth');
+Route::any('/wechat/callback','Wechat\WechatLoginController@callback');
 
 // 测试
 Route::get('test/generate','Test\TestController@generate');

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,7 +21,7 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 // 微信公众号入口
 Route::any('/wechat/entrance','Wechat\WechatApiController@entrance');
 // 微信授权和回调
-Route::any('/wechat/wechatOauth','Wechat\WechatLoginController@wechatAuth');
+Route::any('/wechat/wechatAuth','Wechat\WechatLoginController@wechatAuth');
 Route::any('/wechat/callback','Wechat\WechatLoginController@callback');
 
 // 测试


### PR DESCRIPTION
* 当用户访问一个需要授权页面时，如 baidu.com
* 前端需要调用该授权接口进行授权，授权完后微信会调用回调接口
* 在回调接口里面保存用户信息，并且重定向到用户要访问的页面：baidu.com
* 同时需要将 登录的 token 拼接在重定向页面后面
* 前端通过 页面 url 拿到 token 后，需要将 token 马上截取下来，不能再放到 url 中
* 前端将 token 放入 header 中，方便调用其他登录接口时验证