### PR TITLE
使用 unionid 判断是否是同一个用户

### DIFF
--- a/app/Http/Controllers/MiniPrograms/MiniProgramLoginController.php
+++ b/app/Http/Controllers/MiniPrograms/MiniProgramLoginController.php
@@ -39,14 +39,14 @@ class MiniProgramLoginController extends Controller {
 
             // 这里使用 openid 判断用户是否注册，
             // 如果小程序和公众号是同一个主题，则可以用 unionId 判断是否是同一个用户
-            $userInfo = User::where('openid',$miniProgramUserInfo['openId'])->first();
-            // 如果不用户已经存在，则添加用户信息到数据库
+            $userInfo = User::where('unionid',$miniProgramUserInfo['unionId'])->first();
+            // 如果用户不存在，则添加用户信息到数据库
             if (!$userInfo) {
 
                 $save = [
                     'nickname' => $miniProgramUserInfo['nickName'],
                     'headimgurl' => $miniProgramUserInfo['avatarUrl'],
-                    'openid' => $miniProgramUserInfo['openId'],
+                    'mini_program_openid' => $miniProgramUserInfo['openId'],
                     'unionid' => $miniProgramUserInfo['unionId'],
                     'sex' => $miniProgramUserInfo['gender'],
                     'city' => $miniProgramUserInfo['city'],
@@ -56,6 +56,10 @@ class MiniProgramLoginController extends Controller {
 
                 $id = User::insertGetId($save);
                 $userInfo = User::where('id',$id)->first();
+            } else {    // 存在的话，是否在小程序中授权过，记录小程序 openid
+                if (!$userInfo->mini_program_openid) {
+                    User::where('unionid',$miniProgramUserInfo['unionId'])->update(['mini_program_openid' => $miniProgramUserInfo['openId']]);
+                }
             }
 
             $data['token'] = JwtController::encrypt($userInfo);


### PR DESCRIPTION
如果是同一种项目的话，建议使用 unionid 判断是否是同一个用户
这样如果用户在 公众中做了什么操作，比如购买了订单，在小程序种登录，
这个订单也依然存在，因为是同一个用户。
当然 unionid 需要公众号和小程序绑定开放平台才会有，
并且需要绑定同一个主体才会有，所以看需要而定。
我这里做的是将账号，公众号，小程序，都定为同一个用户